### PR TITLE
Merchant nav

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (8.0.0)
-    bcrypt (3.1.14)
+    bcrypt (3.1.15)
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,12 +1,5 @@
-class Admin::DashboardController < ApplicationController
-  before_action :require_admin
+class Admin::DashboardController < Admin::BaseController
 
   def index
-  end
-
-  private
-
-  def require_admin
-    render file: "/public/404" unless current_admin?
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,4 @@
 class Admin::DashboardController < Admin::BaseController
-
   def index
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,12 @@
 class Admin::DashboardController < ApplicationController
-  def index
+  before_action :require_admin
 
+  def index
   end
 
+  private
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :cart
+  helper_method :cart, :current_user
 
   def cart
     @cart ||= Cart.new(session[:cart] ||= Hash.new(0))
@@ -10,5 +10,4 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,12 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
+
+  def current_admin?
+    current_user && current_user.admin?
+  end
+
+  def current_merchant?
+    current_user && current_user.merchant?
+  end
 end

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -8,6 +8,9 @@ class CartController < ApplicationController
 
   def show
     @items = cart.items
+    if current_admin?
+      render file: "public/404"
+    end
   end
 
   def empty

--- a/app/controllers/merchant/base_controller.rb
+++ b/app/controllers/merchant/base_controller.rb
@@ -1,0 +1,7 @@
+class Merchant::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_merchant?
+  end
+end

--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,6 +1,4 @@
-class Merchant::DashboardController < ApplicationController
+class Merchant::DashboardController < Merchant::BaseController
   def index
-
   end
-
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,1 @@
+<h1>All Users:</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,11 @@
       <%= link_to "All Merchants", "/merchants"%>
       <%= link_to "All Items", "/items"%>
       <%= link_to "Cart: #{cart.total_items}", "/cart" %>
+
+      <% if current_user && current_user.role == "merchant" %>
+        <%= link_to "Dashboard", "/merchant" %>
+      <% end %>
+
     </nav>
     <% flash.each do |name, msg| %>
       <div class= "<%=name%>-flash">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,14 +14,22 @@
       <%= link_to "Register", "/register" %>
       <%= link_to "All Merchants", "/merchants"%>
       <%= link_to "All Items", "/items"%>
-      <%= link_to "Cart: #{cart.total_items}", "/cart" %>
 
       <% if current_user && current_user.role == "merchant" %>
+        <%= link_to "Cart: #{cart.total_items}", "/cart" %>
         <%= link_to "Profile", "/profile" %>
         <%= link_to "Merchant Dashboard", "/merchant" %>
-      <% end %>
 
+      <% elsif current_user && current_user.role == "admin" %>
+        <%= link_to "Profile", "/profile" %>
+        <%= link_to "Admin Dashboard", "/admin" %>
+        <%= link_to "All Users", "/admin/users" %>
+
+      <% else %>
+        <%= link_to "Cart: #{cart.total_items}", "/cart" %>
+      <% end %>
     </nav>
+
     <% flash.each do |name, msg| %>
       <div class= "<%=name%>-flash">
         <p><%= msg %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,13 +10,15 @@
 
   <body>
     <nav class = "topnav">
+      <%= link_to "Home", "/" %>
       <%= link_to "Register", "/register" %>
       <%= link_to "All Merchants", "/merchants"%>
       <%= link_to "All Items", "/items"%>
       <%= link_to "Cart: #{cart.total_items}", "/cart" %>
 
       <% if current_user && current_user.role == "merchant" %>
-        <%= link_to "Dashboard", "/merchant" %>
+        <%= link_to "Profile", "/profile" %>
+        <%= link_to "Merchant Dashboard", "/merchant" %>
       <% end %>
 
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,11 +42,14 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
 
+  get "/users", to: "users#index"
+
   namespace :merchant do
     get "/", to: "dashboard#index"
   end
 
   namespace :admin do
     get "/", to: "dashboard#index"
+    get "/users", to: "users#index"
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe 'Site Navigation' do
       # click_link 'Log out'
       # expect(current_path).to eq('/')
     end
+
+    it "cannot access /admin" do
+      merchant = User.create(name: 'Ross Geller',
+                            address: '33 Banana St',
+                            city: 'New York',
+                            state: 'NY',
+                            zip: '12345',
+                            email: 'dinosaurs_are_cool@turing.io',
+                            password: 'test124',
+                            role: 1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit "/admin"
+
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+    end
   end
 
   describe 'As an admin' do

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -31,7 +31,29 @@ RSpec.describe 'Site Navigation' do
       within 'nav' do
         expect(page).to have_content("Cart: 0")
       end
+    end
+  end
 
+  describe 'As a merchant employee' do
+    it "displays nav bar with same links as a regular user including a link to merchant's dashboard" do
+      merchant = User.create(name: 'Ross Geller',
+                            address: '33 Banana St',
+                            city: 'New York',
+                            state: 'NY',
+                            zip: '12345',
+                            email: 'dinosaurs_are_cool@turing.io',
+                            password: 'test124',
+                            role: 1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit '/merchants'
+
+      within 'nav' do
+        click_link 'Dashboard'
+      end
+
+      expect(current_path).to eq('/merchant')
     end
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Site Navigation' do
   end
 
   describe 'As a merchant employee' do
-    it "displays nav bar with same links as a regular user including a link to merchant's dashboard" do
+    it 'displays nav bar with same links as a regular user including a link to merchant dashboard' do
       merchant = User.create(name: 'Ross Geller',
                             address: '33 Banana St',
                             city: 'New York',
@@ -50,10 +50,19 @@ RSpec.describe 'Site Navigation' do
       visit '/merchants'
 
       within 'nav' do
-        click_link 'Dashboard'
+        click_link 'Merchant Dashboard'
       end
 
       expect(current_path).to eq('/merchant')
+
+      # click_link 'Home'
+      # expect(current_path).to eq('/')
+      # click_link 'All Merchants'
+      # expect(current_path).to eq('/merchants')
+      # click_link 'All Items'
+      # expect(current_path).to eq('/items')
+      # click_link 'Log out'
+      # expect(current_path).to eq('/')
     end
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -65,4 +65,55 @@ RSpec.describe 'Site Navigation' do
       # expect(current_path).to eq('/')
     end
   end
+
+  describe 'As an admin' do
+    it 'displays nav bar with same links as regular user including admin specfic links' do
+      admin = User.create(name: 'Napoleon Bonaparte',
+                          address: '33 Shorty Ave',
+                          city: 'Los Angeles',
+                          state: 'CA',
+                          zip: '12345',
+                          email: 'french_people_rule@turing.io',
+                          password: 'test125',
+                          role: 2)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit '/merchants'
+
+      within 'nav' do
+        click_link 'Home'
+      end
+
+      expect(current_path).to eq('/')
+
+      within 'nav' do
+        click_link 'All Merchants'
+      end
+
+      expect(current_path).to eq('/merchants')
+
+      within 'nav' do
+        click_link 'All Items'
+      end
+
+      expect(current_path).to eq('/items')
+
+      within 'nav' do
+        click_link 'Admin Dashboard'
+      end
+
+      expect(current_path).to eq('/admin')
+
+      within 'nav' do
+        click_link 'All Users'
+      end
+
+      expect(current_path).to eq('/admin/users')
+
+      within 'nav' do
+        expect(page).to_not have_content('Cart: 0')
+      end
+    end
+  end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe 'Site Navigation' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
 
       visit "/admin"
-
       expect(page).to have_content("The page you were looking for doesn't exist (404)")
     end
   end
@@ -131,6 +130,25 @@ RSpec.describe 'Site Navigation' do
       within 'nav' do
         expect(page).to_not have_content('Cart: 0')
       end
+    end
+
+    it "cannot access /merchant or /cart" do
+      admin = User.create(name: 'Napoleon Bonaparte',
+                          address: '33 Shorty Ave',
+                          city: 'Los Angeles',
+                          state: 'CA',
+                          zip: '12345',
+                          email: 'french_people_rule@turing.io',
+                          password: 'test125',
+                          role: 2)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit "/merchant"
+      expect(page).to have_content(" The page you were looking for doesn't exist (404)")
+
+      visit "/cart"
+      expect(page).to have_content(" The page you were looking for doesn't exist (404)")
     end
   end
 end

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -48,6 +48,5 @@ RSpec.describe "Logging in to your account" do
 
     expect(current_path).to eq("/login")
     expect(page).to have_content("Sorry, your credentials are invalid")
-    save_and_open_page
   end
 end


### PR DESCRIPTION
[x] done
User Story 4, Merchant Navigation

As a merchant employee
I see the same links as a regular user
Plus the following links:
- a link to my merchant dashboard ("/merchant")

[x] done
User Story 5, Admin Navigation

As an admin
I see the same links as a regular user
Plus the following links
- a link to my admin dashboard ("/admin")
- a link to see all users ("/admin/users")

Minus the following links/info
- a link to my shopping cart ("/cart") or count of cart items

[x] done

User Story 8, Merchant Navigation Restrictions

As a merchant employee
When I try to access any path that begins with the following, then I see a 404 error:
- '/admin'

[x] done
User Story 9, Admin Navigation Restrictions

As an admin
When I try to access any path that begins with the following, then I see a 404 error:
- '/merchant'
- '/cart'